### PR TITLE
Protect request list from concurrent modification

### DIFF
--- a/Runtime/Snipe/Communicator/Request/AbstractCommunicatorRequest.cs
+++ b/Runtime/Snipe/Communicator/Request/AbstractCommunicatorRequest.cs
@@ -34,7 +34,7 @@ namespace MiniIT.Snipe
 			MessageType = messageType;
 			Data = data;
 
-			_communicator?.Requests.Add(this);
+			_communicator?.AddRequest(this);
 		}
 
 		public void Request(IDictionary<string, object> data, ResponseHandler callback = null)
@@ -155,26 +155,30 @@ namespace MiniIT.Snipe
 				}
 			}
 
-			if (check_duplication)
-			{
-				for (int i = 0; i < _communicator.Requests.Count; i++)
-				{
-					var request = _communicator.Requests[i];
+                        if (check_duplication && _communicator != null)
+                        {
+                                var requestsSnapshot = _communicator.GetRequestsSnapshot();
+                                if (requestsSnapshot != null)
+                                {
+                                        for (int i = 0; i < requestsSnapshot.Count; i++)
+                                        {
+                                                var request = requestsSnapshot[i];
 
-					if (request == null)
-						continue;
+                                                if (request == null)
+                                                        continue;
 
-					if (object.ReferenceEquals(request, this))
-						break;
+                                                if (ReferenceEquals(request, this))
+                                                        break;
 
-					if (string.Equals(request.MessageType, this.MessageType, StringComparison.Ordinal) &&
-					    CheckDataIsFullyContained(request.Data, this.Data))
-					{
-						_requestId = request._requestId;
-						break;
-					}
-				}
-			}
+                                                if (string.Equals(request.MessageType, this.MessageType, StringComparison.Ordinal) &&
+                                                    CheckDataIsFullyContained(request.Data, this.Data))
+                                                {
+                                                        _requestId = request._requestId;
+                                                        break;
+                                                }
+                                        }
+                                }
+                        }
 
 			if (_requestId != 0)
 			{
@@ -292,10 +296,7 @@ namespace MiniIT.Snipe
 		{
 			if (_communicator != null)
 			{
-				if (_communicator.Requests != null)
-				{
-					_communicator.Requests.Remove(this);
-				}
+                                _communicator.RemoveRequest(this);
 
 				_communicator.ConnectionEstablished -= OnCommunicatorReady;
 				_communicator.ReconnectionScheduled -= OnReconnectionScheduled;


### PR DESCRIPTION
## Summary
- guard SnipeCommunicator request bookkeeping with a dedicated lock and snapshot helpers to avoid concurrent modification
- update AbstractCommunicatorRequest to use the new helpers when adding/removing requests and when checking for duplicates
- dispose snapshots of room requests safely before issuing Dispose calls

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68da9b7ab414832193d95138713272a8