### PR TITLE
Correction of receiving version for UWP&WSA

### DIFF
--- a/Runtime/Snipe.Unity/Services/SystemInfo/WindowsSystemInfoExtractor.cs
+++ b/Runtime/Snipe.Unity/Services/SystemInfo/WindowsSystemInfoExtractor.cs
@@ -9,20 +9,19 @@ namespace MiniIT.Snipe
 			var eascdi = new Windows.Security.ExchangeActiveSyncProvisioning.EasClientDeviceInformation();
 
 			string dfv = Windows.System.Profile.AnalyticsInfo.VersionInfo.DeviceFamilyVersion;
-			var osVersion = new Version();
+			string osVersion = "0.0";
 			if (ulong.TryParse(dfv, out ulong v))
 			{
-				osVersion.Major = (int)((v & 0xFFFF000000000000L) >> 48);
-				osVersion.Minor = (int)((v & 0x0000FFFF00000000L) >> 32);
-				// osVersion.Build = (int)((v & 0x00000000FFFF0000L) >> 16);
-				// osVersion.Revision = (int)(v & 0x000000000000FFFFL);
+				var major = (int)((v & 0xFFFF000000000000L) >> 48);
+				var minor = (int)((v & 0x0000FFFF00000000L) >> 32);
+				osVersion = $"{major}.{minor}";
 			}
 
 			return new SystemInformation()
 			{
 				DeviceManufacturer = eascdi.SystemManufacturer,
 				OperatingSystemFamily = eascdi.OperatingSystem,
-				OperatingSystemVersion = $"{osVersion.Major}.{osVersion.Minor}",
+				OperatingSystemVersion = osVersion,
 			};
 		}
 	}

--- a/Runtime/Snipe.Unity/Services/SystemInfo/WindowsSystemInfoExtractor.cs
+++ b/Runtime/Snipe.Unity/Services/SystemInfo/WindowsSystemInfoExtractor.cs
@@ -9,19 +9,19 @@ namespace MiniIT.Snipe
 			var eascdi = new Windows.Security.ExchangeActiveSyncProvisioning.EasClientDeviceInformation();
 
 			string dfv = Windows.System.Profile.AnalyticsInfo.VersionInfo.DeviceFamilyVersion;
-			string osVersion = "0.0";
+			int major = 0;
+			int minor = 0;
 			if (ulong.TryParse(dfv, out ulong v))
 			{
-				var major = (int)((v & 0xFFFF000000000000L) >> 48);
-				var minor = (int)((v & 0x0000FFFF00000000L) >> 32);
-				osVersion = $"{major}.{minor}";
+				major = (int)((v & 0xFFFF000000000000L) >> 48);
+				minor = (int)((v & 0x0000FFFF00000000L) >> 32);
 			}
 
 			return new SystemInformation()
 			{
 				DeviceManufacturer = eascdi.SystemManufacturer,
 				OperatingSystemFamily = eascdi.OperatingSystem,
-				OperatingSystemVersion = osVersion,
+				OperatingSystemVersion = $"{major}.{minor}",
 			};
 		}
 	}


### PR DESCRIPTION
Изменение логики получения версии для платформ WSA и UWP.
Фикс бага при сборке :


`[error] [2026-08-05T09:57:51Z - Unity] Library\PackageCache\com.miniit.snipe.client@bc1149fc81ee\Runtime\Snipe.Unity\Services\SystemInfo\WindowsSystemInfoExtractor.cs(12,24): error CS0246: The type or namespace name 'Version' could not be found (are you missing a using directive or an assembly reference?)`

