### PR TITLE
Bugfix: `UnityWebRequest` timeout NRE

### DIFF
--- a/Runtime/HttpClient/UnityHttpClient/UnityHttpClient.cs
+++ b/Runtime/HttpClient/UnityHttpClient/UnityHttpClient.cs
@@ -132,25 +132,19 @@ namespace MiniIT.Http
 				return await SendRequestAsync(request, cancellationToken);
 			}
 
+			request.timeout = Math.Max(1, (int)Math.Ceiling(timeout.TotalSeconds));
 			request.downloadHandler = new DownloadHandlerBuffer();
-			using var timeoutCts = new CancellationTokenSource(timeout);
-			using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, cancellationToken);
 			try
 			{
-				await request.SendWebRequest().ToUniTask(cancellationToken: linkedCts.Token, cancelImmediately: true);
+				// Passing a timeout token to UniTask makes it call UnityWebRequest.Abort().
+				await request.SendWebRequest().ToUniTask();
 				return new UnityHttpClientResponse(request);
-			}
-			catch (OperationCanceledException)
-			{
-				request.Abort();
-				return UnityHttpClientResponse.CreateTimeout();
 			}
 			catch (UnityWebRequestException e)
 			{
 				if (string.Equals(request.error, REQUEST_TIMEOUT_ERROR, StringComparison.OrdinalIgnoreCase) ||
 				    string.Equals(e.Message, REQUEST_TIMEOUT_ERROR, StringComparison.OrdinalIgnoreCase))
 				{
-					request.Abort();
 					return UnityHttpClientResponse.CreateTimeout();
 				}
 


### PR DESCRIPTION
[NRE during Snipe tables/config loading when version.json requests timeout](https://app.asana.com/1/1180656739323347/project/1211181944629783/task/1217144751568602)
---
Таймауты сетевых запросов теперь обрабатываются самим Unity, без принудительного прерывания запроса. Это устраняет случайные ошибки при недоступности сервера или долгом ответе.

Нюанс: отмена уже начатого запроса может занять до заданного лимита времени (1–5 секунд), но приложение продолжит корректно использовать запасные данные.