### PR TITLE
Bugfix: `UnityWebRequest` abort NRE

### DIFF
--- a/Runtime/HttpClient/UnityHttpClient/UnityHttpClient.cs
+++ b/Runtime/HttpClient/UnityHttpClient/UnityHttpClient.cs
@@ -137,20 +137,33 @@ namespace MiniIT.Http
 			using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, cancellationToken);
 			try
 			{
-				await request.SendWebRequest().ToUniTask(cancellationToken: linkedCts.Token, cancelImmediately: true);
+				var operation = request.SendWebRequest();
+				using var cancellationRegistration = linkedCts.Token.RegisterWithoutCaptureExecutionContext(static state =>
+				{
+					try
+					{
+						((UnityWebRequest)state).Abort();
+					}
+					catch (NullReferenceException)
+					{
+					}
+				}, request);
+
+				await operation.ToUniTask();
+
+				if (linkedCts.IsCancellationRequested)
+				{
+					return UnityHttpClientResponse.CreateTimeout();
+				}
+
 				return new UnityHttpClientResponse(request);
-			}
-			catch (OperationCanceledException)
-			{
-				request.Abort();
-				return UnityHttpClientResponse.CreateTimeout();
 			}
 			catch (UnityWebRequestException e)
 			{
-				if (string.Equals(request.error, REQUEST_TIMEOUT_ERROR, StringComparison.OrdinalIgnoreCase) ||
+				if (linkedCts.IsCancellationRequested ||
+				    string.Equals(request.error, REQUEST_TIMEOUT_ERROR, StringComparison.OrdinalIgnoreCase) ||
 				    string.Equals(e.Message, REQUEST_TIMEOUT_ERROR, StringComparison.OrdinalIgnoreCase))
 				{
-					request.Abort();
 					return UnityHttpClientResponse.CreateTimeout();
 				}
 


### PR DESCRIPTION
[NRE during Snipe tables/config loading when version.json requests timeout](https://app.asana.com/1/1180656739323347/project/1211181944629783/task/1217144751568602)
---
В `UnityHttpClient` изменён путь запросов с явным timeout:
- отмена больше не передаётся в `UniTask.ToUniTask`, чтобы UniTask не вызывал `UnityWebRequest.Abort()` из PlayerLoop;
- `Abort()` вызывается из callback linked-token и защищён от `NullReferenceException`;
- отмена после завершения запроса и ошибка после `Abort()` по-прежнему мапятся в `CreateTimeout()`;
- callback не создаёт closure и не захватывает `ExecutionContext`.

Путь запросов без явного timeout не изменён.